### PR TITLE
Add Field Property is_hw_readable/writable

### DIFF
--- a/systemrdl/node.py
+++ b/systemrdl/node.py
@@ -1025,6 +1025,26 @@ class FieldNode(VectorNode):
                         rdltypes.AccessType.r)
 
     @property
+    def is_hw_writable(self) -> bool:
+        """
+        Field is writable by software
+        """
+        hw = self.get_property('hw')
+
+        return hw in (rdltypes.AccessType.rw, rdltypes.AccessType.rw1,
+                        rdltypes.AccessType.w, rdltypes.AccessType.w1)
+
+    @property
+    def is_hw_readable(self) -> bool:
+        """
+        Field is readable by software
+        """
+        hw = self.get_property('hw')
+
+        return hw in (rdltypes.AccessType.rw, rdltypes.AccessType.rw1,
+                        rdltypes.AccessType.r)
+
+    @property
     def implements_storage(self) -> bool:
         """
         True if combination of field access properties imply that the field

--- a/systemrdl/node.py
+++ b/systemrdl/node.py
@@ -1027,7 +1027,7 @@ class FieldNode(VectorNode):
     @property
     def is_hw_writable(self) -> bool:
         """
-        Field is writable by software
+        Field is writable by hardware
         """
         hw = self.get_property('hw')
 
@@ -1037,7 +1037,7 @@ class FieldNode(VectorNode):
     @property
     def is_hw_readable(self) -> bool:
         """
-        Field is readable by software
+        Field is readable by hardware
         """
         hw = self.get_property('hw')
 

--- a/test/test_node_utils.py
+++ b/test/test_node_utils.py
@@ -384,6 +384,14 @@ class TestNodeUtils(RDLSourceTestCase):
         self.assertFalse(f5.is_sw_writable)
         self.assertFalse(f6.is_sw_writable)
 
+        self.assertFalse(f1.is_hw_writable)
+        self.assertTrue(f2.is_hw_writable)
+        self.assertTrue(f3.is_hw_writable)
+
+        self.assertTrue(f1.is_hw_readable)
+        self.assertFalse(f2.is_hw_readable)
+        self.assertTrue(f3.is_hw_readable)
+
         self.assertTrue(r1.has_sw_writable)
         self.assertTrue(r1.has_sw_readable)
 


### PR DESCRIPTION
Currently fields have a pair of properties to determine is_sw_readable/writeable. The same logic can be replicated for HW access. 