### PR TITLE
Memory properties for sw access

### DIFF
--- a/systemrdl/node.py
+++ b/systemrdl/node.py
@@ -1177,6 +1177,26 @@ class MemNode(AddressableNode):
         num_entries = self.get_property('mementries')
         return entry_size * num_entries
 
+    @property
+    def is_sw_writable(self) -> bool:
+        """
+        Memory is writable by software
+        """
+        sw = self.get_property('sw')
+
+        return sw in (rdltypes.AccessType.rw, rdltypes.AccessType.rw1,
+                        rdltypes.AccessType.w, rdltypes.AccessType.w1)
+
+    @property
+    def is_sw_readable(self) -> bool:
+        """
+        Memory is readable by software
+        """
+        sw = self.get_property('sw')
+
+        return sw in (rdltypes.AccessType.rw, rdltypes.AccessType.rw1,
+                        rdltypes.AccessType.r)
+
 #===============================================================================
 def get_group_node_size(node: Union[AddrmapNode, RegfileNode]) -> int:
     """

--- a/test/rdl_src/memories.rdl
+++ b/test/rdl_src/memories.rdl
@@ -1,0 +1,39 @@
+addrmap memories {
+
+    external mem {
+        mementries = 2;
+        memwidth = 32;
+        sw = w;
+    } mem_2_32_w;
+
+    external mem {
+        mementries = 2;
+        memwidth = 32;
+        sw = r;
+    } mem_2_32_r;
+
+    external mem {
+        mementries = 2;
+        memwidth = 32;
+        sw = rw;
+    } mem_2_32_rw;
+
+    external mem {
+        mementries = 5;
+        memwidth = 64;
+        sw = w;
+    } mem_5_64_w;
+
+    external mem {
+        mementries = 5;
+        memwidth = 64;
+        sw = r;
+    } mem_5_64_r;
+
+    external mem {
+        mementries = 5;
+        memwidth = 64;
+        sw = rw;
+    } mem_5_64_rw;
+
+};

--- a/test/test_memories.py
+++ b/test/test_memories.py
@@ -1,0 +1,38 @@
+from unittest_utils import RDLSourceTestCase
+
+class TestMemories(RDLSourceTestCase):
+
+    def test_basic(self):
+        root = self.compile(
+            ["rdl_src/memories.rdl"],
+            "memories"
+        )
+
+        extern_map = {
+            "mem_2_32_w": { 'entries' : 2, 'width' : 32, 'sw_access': 'w'},
+            "mem_2_32_r": {'entries': 2, 'width': 32, 'sw_access': 'r'},
+            "mem_2_32_rw": {'entries': 2, 'width': 32, 'sw_access': 'rw'},
+            "mem_5_64_w": {'entries': 5, 'width': 64, 'sw_access': 'w'},
+            "mem_5_64_r": {'entries': 5, 'width': 64, 'sw_access': 'r'},
+            "mem_5_64_rw": {'entries': 5, 'width': 64, 'sw_access': 'rw'},
+        }
+
+        for name, props in extern_map.items():
+            with self.subTest(name):
+                mem = root.find_by_path("memories.%s" % name)
+                self.assertEqual(mem.external, True)
+
+                if props['sw_access'] == 'w':
+                    self.assertEqual(mem.is_sw_readable, False)
+                    self.assertEqual(mem.is_sw_writable, True)
+                elif props['sw_access'] == 'r':
+                    self.assertEqual(mem.is_sw_readable, True)
+                    self.assertEqual(mem.is_sw_writable, False)
+                elif props['sw_access'] == 'rw':
+                    self.assertEqual(mem.is_sw_readable, True)
+                    self.assertEqual(mem.is_sw_writable, True)
+                else:
+                    raise ValueError('unrecognised software access type: %s'% props['sw_access'])
+
+                size_in_bytes = (props['width'] >> 3) * props['entries']
+                self.assertEqual(mem.size, size_in_bytes)


### PR DESCRIPTION
Added two new properties to the `MemNode` Component:

- `is_sw_writable` used to determine if the memory is software writeable
- `is_sw_readable` used to determine if the memory is software readable