### PR TITLE
Include offending text in "illegal name" import errors.

### DIFF
--- a/systemrdl/importer.py
+++ b/systemrdl/importer.py
@@ -50,7 +50,7 @@ class RDLImporter:
     # ------------------------ create_xxx_definition() -------------------------
     def _create_definition(self, cls: "Type[ComponentClass]", type_name: Optional[str] = None, src_ref: Optional[SourceRefBase] = None) -> "ComponentClass":
         if (type_name is not None) and not re.fullmatch(r"\w+", type_name):
-            raise ValueError("Type name has invalid characters")
+            raise ValueError(f"Type name has invalid characters: {type_name}")
         C = cls()
         C.type_name = type_name
         C.def_src_ref = src_ref or self.default_src_ref
@@ -134,7 +134,7 @@ class RDLImporter:
         if comp_def.is_instance:
             raise ValueError("Component is already instantiated")
         if not re.fullmatch(r"\w+", inst_name):
-            raise ValueError("Instance name has invalid characters")
+            raise ValueError(f"Instance name has invalid characters: {inst_name}")
 
         if comp_def.type_name is None:
             # anonymous definition. No need to copy since it can only be used once

--- a/systemrdl/importer.py
+++ b/systemrdl/importer.py
@@ -50,7 +50,7 @@ class RDLImporter:
     # ------------------------ create_xxx_definition() -------------------------
     def _create_definition(self, cls: "Type[ComponentClass]", type_name: Optional[str] = None, src_ref: Optional[SourceRefBase] = None) -> "ComponentClass":
         if (type_name is not None) and not re.fullmatch(r"\w+", type_name):
-            raise ValueError(f"Type name has invalid characters: {type_name}")
+            raise ValueError(f"Type name has invalid characters: {type_name!r}")
         C = cls()
         C.type_name = type_name
         C.def_src_ref = src_ref or self.default_src_ref
@@ -134,7 +134,7 @@ class RDLImporter:
         if comp_def.is_instance:
             raise ValueError("Component is already instantiated")
         if not re.fullmatch(r"\w+", inst_name):
-            raise ValueError(f"Instance name has invalid characters: {inst_name}")
+            raise ValueError(f"Instance name has invalid characters: {inst_name!r}")
 
         if comp_def.type_name is None:
             # anonymous definition. No need to copy since it can only be used once

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -130,11 +130,11 @@ class TestImporter(unittest.TestCase):
     def test_illegal_inst_name_import_raises_error(self):
         rdlc = RDLCompiler()
         i = InstNameErrorTestcaseImporter(rdlc)
-        with self.assertRaisesRegex(ValueError, "Instance name has invalid characters: reg1.some_signal"):
+        with self.assertRaisesRegex(ValueError, "Instance name has invalid characters: 'reg1.some_signal'"):
             i.import_file("asdf")
 
     def test_illegal_type_name_import_raises_error(self):
         rdlc = RDLCompiler()
         i = TypeNameErrorTestcaseImporter(rdlc)
-        with self.assertRaisesRegex(ValueError, "Type name has invalid characters: illegal.type.name"):
+        with self.assertRaisesRegex(ValueError, "Type name has invalid characters: 'illegal.type.name'"):
             i.import_file("asdf")

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -64,6 +64,28 @@ class MyImporter(RDLImporter):
         )
 
 
+class InstNameErrorTestcaseImporter(RDLImporter):
+    def import_file(self, path: str) -> None:
+        super().import_file(path)
+
+        my_rf = self.create_regfile_definition("error_testcases")
+        self.register_root_component(my_rf)
+
+        # Creates a register instance with an illegal name.
+        reg1 = self.instantiate_reg(self.create_reg_definition(),
+                                    "reg1.some_signal", 0)
+        self.add_child(my_rf, reg1)
+
+class TypeNameErrorTestcaseImporter(RDLImporter):
+
+    def import_file(self, path: str) -> None:
+        super().import_file(path)
+
+        my_rf = self.create_regfile_definition("error_testcases")
+        self.register_root_component(my_rf)
+
+        # Creates a register instance with an illegal name.
+        reg_t = self.create_reg_definition("illegal.type.name")
 
 class TestImporter(unittest.TestCase):
     def test_importer(self):
@@ -104,3 +126,15 @@ class TestImporter(unittest.TestCase):
         ]
 
         self.assertEqual(nodes, expected_nodes)
+
+    def test_illegal_inst_name_import_raises_error(self):
+        rdlc = RDLCompiler()
+        i = InstNameErrorTestcaseImporter(rdlc)
+        with self.assertRaisesRegex(ValueError, "Instance name has invalid characters: reg1.some_signal"):
+            i.import_file("asdf")
+
+    def test_illegal_type_name_import_raises_error(self):
+        rdlc = RDLCompiler()
+        i = TypeNameErrorTestcaseImporter(rdlc)
+        with self.assertRaisesRegex(ValueError, "Type name has invalid characters: illegal.type.name"):
+            i.import_file("asdf")


### PR DESCRIPTION
When encountering an import error due to invalid names while parsing large IP-XACT files, it really helps pinpoint the error if the offending text is included in the exception.