### PR TITLE
Add py.typed to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include LICENSE-3RD-PARTY
 include systemrdl/preprocessor/ppp_runner.pl
+include systemrdl/py.typed
 recursive-include systemrdl/parser/ext *
 recursive-exclude test *


### PR DESCRIPTION
This ensures that the py.typed marker is included in source distributions and wheels. Currently the file is being dropped causing mypy to complain.