### PR TITLE
Fix pylint error R0917.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,15 @@ How to submit a PR:
 4. Ensure the test suite passes.
 5. Submit the pull request!
 
+## Run the tests
+Run: test/run.sh
+
+If you see an error like:
+```
+fatal error: Python.h: No such file or directory
+```
+then install the header files and static libraries for python dev as instructed
+at https://stackoverflow.com/questions/21530577
 
 ## Any contributions you make will be under the MIT Software License
 In short, when you submit code changes, your submissions are understood to be

--- a/test/pylint.rc
+++ b/test/pylint.rc
@@ -496,6 +496,7 @@ ignored-parents=
 
 # Maximum number of arguments for function / method.
 max-args=8
+max-positional-arguments=8
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7


### PR DESCRIPTION
See:
1. https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-many-positional-arguments.html
2. https://github.com/pylint-dev/pylint/commit/de6e6fae34cccd2e7587a46450c833258e3000cb