### PR TITLE
Fix bug when using parameter for field-width.

### DIFF
--- a/src/systemrdl/ast/sequence.py
+++ b/src/systemrdl/ast/sequence.py
@@ -75,7 +75,6 @@ class Replicate(ASTNode):
         self.reps = reps
         self.concat = concat
         self.type: Union[Type[int], Type[str]] = int
-        self.reps_value: Optional[int] = None
 
     def predict_type(self) -> Union[Type[int], Type[str]]:
 
@@ -100,28 +99,26 @@ class Replicate(ASTNode):
 
     def get_min_eval_width(self, assignee_node: Optional['Node']) -> int:
         # Evaluate number of repetitions
-        if self.reps_value is None:
-            self.reps_value = self.reps.get_value(assignee_node=assignee_node)
+        reps_value = self.reps.get_value(assignee_node=assignee_node)
 
         if self.type == int:
             # Get width of single contents
             width = self.concat.get_min_eval_width(assignee_node)
-            width *= self.reps_value
+            width *= reps_value
             return width
         else:
             raise RuntimeError
 
     def get_value(self, eval_width: Optional[int]=None, assignee_node: Optional['Node']=None) -> Union[int, str]:
         # Evaluate number of repetitions
-        if self.reps_value is None:
-            self.reps_value = self.reps.get_value(assignee_node=assignee_node)
+        reps_value = self.reps.get_value(assignee_node=assignee_node)
 
         if self.type == int:
             width = self.concat.get_min_eval_width(assignee_node)
             val = int(self.concat.get_value(assignee_node=assignee_node))
 
             int_result = 0
-            for _ in range(self.reps_value):
+            for _ in range(reps_value):
                 int_result <<= width
                 int_result |= val
 
@@ -129,7 +126,7 @@ class Replicate(ASTNode):
 
         elif self.type == str:
             str_result = self.concat.get_value(assignee_node=assignee_node)
-            str_result *= self.reps_value
+            str_result *= reps_value
             return str_result
 
         else:

--- a/test/rdl_src/parameterized_expr.rdl
+++ b/test/rdl_src/parameterized_expr.rdl
@@ -1,0 +1,13 @@
+addrmap top {
+
+  regfile regfile_t #(longint FIELD_WIDTH = 5) {
+
+    reg {
+      field {} f[8+FIELD_WIDTH-1:8] = {FIELD_WIDTH{1'b1}};
+    } reg_x;
+  };
+
+  regfile_t rf_default;
+  regfile_t #(.FIELD_WIDTH(4)) rf_four;
+  regfile_t #(.FIELD_WIDTH(6)) rf_six;
+};

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -234,3 +234,15 @@ class TestParameters(RDLSourceTestCase):
             "parameters2",
             r"Parameter 'PARAM' contains a reference. SystemRDL does not allow component references inside parameter values."
         )
+
+    def test_expr(self):
+        root = self.compile(['rdl_src/parameterized_expr.rdl'], 'top')
+
+        field = root.find_by_path('top.rf_default.reg_x.f');
+        self.assertEqual(field.get_property('reset'), 0x1f);
+
+        field = root.find_by_path('top.rf_four.reg_x.f');
+        self.assertEqual(field.get_property('reset'), 0xf);
+
+        field = root.find_by_path('top.rf_six.reg_x.f');
+        self.assertEqual(field.get_property('reset'), 0x3f);


### PR DESCRIPTION
Caching Replicate.reps_value causes the parameterized field-width to be "locked" to the value of the parameter that is used for the first instantiation of some component type.

Then all subsequent instantiations reuse that value, even if a different parameter value was specified in the code.

The fix is to not cache the reps_value.