### PR TITLE
Prepare for experimental implementation of hetero-array support.

### DIFF
--- a/src/systemrdl/flags.py
+++ b/src/systemrdl/flags.py
@@ -1,0 +1,6 @@
+from absl import flags
+
+HETERO_ARRAYS = flags.DEFINE_bool(
+    'experimental_hetero_arrays',
+    False,
+    'Support heterogeneous arrays.')

--- a/test/rdl_err_src/hetero_array.rdl
+++ b/test/rdl_err_src/hetero_array.rdl
@@ -1,0 +1,13 @@
+addrmap top {
+  reg reg_t {
+    field{} f;
+  };
+
+  regfile {
+    reg {
+      field {} f;
+    } some_reg;
+  } some_rf[2];
+
+  some_ref[0].some_reg->name = "foobar";
+};

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
+absl-py
 pytest
 pytest-cov
 parameterized

--- a/test/test_hetero_array.py
+++ b/test/test_hetero_array.py
@@ -1,0 +1,16 @@
+from absl.testing import flagsaver
+from unittest_utils import RDLSourceTestCase
+
+class TestHeteroArray(RDLSourceTestCase):
+    """Test hetero arrays."""
+
+    maxDiff = None  # pylint: disable=invalid-name
+
+    @flagsaver.flagsaver(experimental_hetero_arrays=False)
+    def test_disabled(self):
+        self.assertRDLCompileError(
+                ['rdl_err_src/hetero_array.rdl'],
+                None,
+                'Use of array suffixes in dynamic property assignments is not'
+                ' supported',
+        )

--- a/test/unittest_utils.py
+++ b/test/unittest_utils.py
@@ -3,6 +3,8 @@ import os
 import logging
 import re
 
+import systemrdl.flags
+
 from antlr4 import InputStream
 from systemrdl import RDLCompiler
 from systemrdl.parser import sa_systemrdl


### PR DESCRIPTION
We have a working implementation, with many tests.

I plan to upstream the functionality in stages along with the relevant tests.

This change adds a guard flag that can be easily enabled when running any tool that embeds the compiler.